### PR TITLE
Introduce an "explicit ABI" concept

### DIFF
--- a/Generic-Binding-Lib-Sample/MainActivity.cs
+++ b/Generic-Binding-Lib-Sample/MainActivity.cs
@@ -48,19 +48,25 @@ namespace Generic_Binding_Lib_Sample
 		{
 			readonly List<T> list = new List<T> ();
 
-			public bool Add (T p0)
+			public bool Add (T? p0)
 			{
+				if (p0 == null) {
+					return false;
+				}
 				list.Add (p0);
 				return true;
 			}
 
-			public bool AddAll (ICollection<T> p0)
+			public bool AddAll (ICollection<T>? p0)
 			{
+				if (p0 == null) {
+					return false;
+				}
 				list.AddRange (p0);
 				return true;
 			}
 
-			public T Get (int p0)
+			public T? Get (int p0)
 			{
 				return list [p0];
 			}
@@ -85,20 +91,23 @@ namespace Generic_Binding_Lib_Sample
 			System.Diagnostics.Debug.WriteLine (t2);
 
 			var tv = FindViewById<TextView> (Resource.Id.textView1);
+			if (tv == null) {
+				return;
+			}
 
 			tv.Text = t1 + System.Environment.NewLine + t2;
 		}
 
 		public class MyErasedGenericType : ErasedGenericType
 		{
-			public override void PerformanceMethod (Java.Lang.Object p0)
+			public override void PerformanceMethod (Java.Lang.Object? p0)
 			{
 			}
 		}
 
 		public class MyGenericType<T> : GenericType<T> where T : Java.Lang.Object
 		{
-			public override void PerformanceMethod (T p0)
+			public override void PerformanceMethod (T? p0)
 			{
 			}
 		}

--- a/Generic-Binding-Lib/Additions/Example.CustomListConsumer.cs
+++ b/Generic-Binding-Lib/Additions/Example.CustomListConsumer.cs
@@ -57,7 +57,7 @@ namespace Example {
 			}
 		}
 
-		static Delegate cb_add_Ljava_lang_Object_;
+		static Delegate? cb_add_Ljava_lang_Object_;
 #pragma warning disable 0169
 		static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
@@ -70,14 +70,14 @@ namespace Example {
 		{
 			var __this = global::Java.Lang.Object.GetObject<global::Example.CustomListConsumer> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
-			bool __ret = __this.Add (p0);
+			bool __ret = __this!.Add (p0);
 			return __ret;
 		}
 #pragma warning restore 0169
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='example']/class[@name='CustomListConsumer']/method[@name='add' and count(parameter)=1 and parameter[1][@type='E']]"
 		[Register ("add", "(Ljava/lang/Object;)Z", "GetAdd_Ljava_lang_Object_Handler")]
-		public virtual unsafe bool Add (global::Java.Lang.Object p0)
+		public virtual unsafe bool Add (global::Java.Lang.Object? p0)
 		{
 			const string __id = "add.(Ljava/lang/Object;)Z";
 			IntPtr native_p0 = JNIEnv.ToLocalJniHandle (p0);
@@ -92,7 +92,7 @@ namespace Example {
 			}
 		}
 
-		static Delegate cb_addAll_Ljava_util_Collection_;
+		static Delegate? cb_addAll_Ljava_util_Collection_;
 #pragma warning disable 0169
 		static Delegate GetAddAll_Ljava_util_Collection_Handler ()
 		{
@@ -105,14 +105,14 @@ namespace Example {
 		{
 			var __this = global::Java.Lang.Object.GetObject<global::Example.CustomListConsumer> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var p0 = global::Android.Runtime.JavaCollection.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
-			bool __ret = __this.AddAll (p0);
+			bool __ret = __this!.AddAll (p0);
 			return __ret;
 		}
 #pragma warning restore 0169
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='example']/class[@name='CustomListConsumer']/method[@name='addAll' and count(parameter)=1 and parameter[1][@type='java.util.Collection&lt;? extends E&gt;']]"
 		[Register ("addAll", "(Ljava/util/Collection;)Z", "GetAddAll_Ljava_util_Collection_Handler")]
-		public virtual unsafe bool AddAll (global::System.Collections.ICollection p0)
+		public virtual unsafe bool AddAll (global::System.Collections.ICollection? p0)
 		{
 			const string __id = "addAll.(Ljava/util/Collection;)Z";
 			IntPtr native_p0 = global::Android.Runtime.JavaCollection.ToLocalJniHandle (p0);
@@ -127,7 +127,7 @@ namespace Example {
 			}
 		}
 
-		static Delegate cb_get_I;
+		static Delegate? cb_get_I;
 #pragma warning disable 0169
 		static Delegate GetGet_IHandler ()
 		{
@@ -139,20 +139,20 @@ namespace Example {
 		static IntPtr n_Get_I (IntPtr jnienv, IntPtr native__this, int p0)
 		{
 			var __this = global::Java.Lang.Object.GetObject<global::Example.CustomListConsumer> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.Get (p0));
+			return JNIEnv.ToLocalJniHandle (__this!.Get (p0));
 		}
 #pragma warning restore 0169
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='example']/class[@name='CustomListConsumer']/method[@name='get' and count(parameter)=1 and parameter[1][@type='int']]"
 		[Register ("get", "(I)Ljava/lang/Object;", "GetGet_IHandler")]
-		public virtual unsafe global::Java.Lang.Object Get (int p0)
+		public virtual unsafe global::Java.Lang.Object? Get (int p0)
 		{
 			const string __id = "get.(I)Ljava/lang/Object;";
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (p0);
 				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
-				return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				return (global::Java.Lang.Object?) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
 			} finally {
 			}
 		}

--- a/Generic-Binding-Lib/Additions/Example.ErasedGenericType.cs
+++ b/Generic-Binding-Lib/Additions/Example.ErasedGenericType.cs
@@ -53,7 +53,7 @@ namespace Example {
 			}
 		}
 
-		static Delegate cb_PerformanceMethod_Ljava_lang_Object_;
+		static Delegate? cb_PerformanceMethod_Ljava_lang_Object_;
 #pragma warning disable 0169
 		static Delegate GetPerformanceMethod_Ljava_lang_Object_Handler ()
 		{
@@ -66,13 +66,13 @@ namespace Example {
 		{
 			var __this = global::Java.Lang.Object.GetObject<global::Example.ErasedGenericType> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
-			__this.PerformanceMethod (p0);
+			__this!.PerformanceMethod (p0);
 		}
 #pragma warning restore 0169
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='example']/class[@name='ErasedGenericType']/method[@name='PerformanceMethod' and count(parameter)=1 and parameter[1][@type='T']]"
 		[Register ("PerformanceMethod", "(Ljava/lang/Object;)V", "GetPerformanceMethod_Ljava_lang_Object_Handler")]
-		public virtual unsafe void PerformanceMethod (global::Java.Lang.Object p0)
+		public virtual unsafe void PerformanceMethod (global::Java.Lang.Object? p0)
 		{
 			const string __id = "PerformanceMethod.(Ljava/lang/Object;)V";
 			IntPtr native_p0 = JNIEnv.ToLocalJniHandle (p0);

--- a/Generic-Binding-Lib/Additions/Example.GenericType.cs
+++ b/Generic-Binding-Lib/Additions/Example.GenericType.cs
@@ -8,67 +8,52 @@ internal delegate IntPtr _JniMarshal_PPI_L (IntPtr jnienv, IntPtr klass, int p0)
 
 namespace Example
 {
-	public interface IGenericTypeInvoker : IJavaObject, Java.Interop.IJavaPeerable
-	{
-		static readonly Java.Interop.JniPeerMembers _members = new XAPeerMembers ("example/GenericType", typeof (IGenericTypeInvoker));
-
-		void InvokePerformanceMethod (global::Java.Lang.Object obj);
-
-		static Delegate cb_PerformanceMethod_Ljava_lang_Object_;
-#pragma warning disable 0169
-		static Delegate GetPerformanceMethod_Ljava_lang_Object_Handler ()
-		{
-			if (cb_PerformanceMethod_Ljava_lang_Object_ == null)
-				cb_PerformanceMethod_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_PerformanceMethod_Ljava_lang_Object_);
-			return cb_PerformanceMethod_Ljava_lang_Object_;
-		}
-
-		static void n_PerformanceMethod_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
-		{
-			var __this = global::Java.Lang.Object.GetObject<global::Example.IGenericTypeInvoker> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
-			__this.InvokePerformanceMethod (p0);
-		}
-#pragma warning restore 0169
-	}
-
 	[global::Android.Runtime.Register ("example/GenericType", "", "Example.IGenericTypeInvoker", DoNotGenerateAcw = true)]
-	public partial class GenericType<T> : global::Java.Lang.Object, IGenericTypeInvoker where T : global::Java.Lang.Object
+	public partial class GenericType : global::Java.Lang.Object, global::jniabi.example._JniabiGenericType
 	{
-		[Register ("PerformanceMethod", "(Ljava/lang/Object;)V", "GetPerformanceMethod_Ljava_lang_Object_Handler:Example.IGenericTypeInvoker, Generic-Binding-Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
-		public virtual unsafe void PerformanceMethod (T p0) { }
+		[Register ("PerformanceMethod", "(Ljava/lang/Object;)V", "GetPerformanceMethod_Ljava_lang_Object_Handler:jniabi.example._JniabiGenericType, Generic-Binding-Lib")]
+		public virtual unsafe void PerformanceMethod (Java.Lang.Object? p0)
+		{
+			jniabi.example.JniabiGenericType.PerformanceMethod (this, p0?.PeerReference ?? default);
+		}
 
-		public void InvokePerformanceMethod (global::Java.Lang.Object obj) => PerformanceMethod (obj.JavaCast<T> ());
+		void global::jniabi.example._JniabiGenericType.PerformanceMethod (global::Java.Interop.JniObjectReference native_p0)
+		{
+			var p0 = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_p0.Handle, JniHandleOwnership.DoNotTransfer);
+			PerformanceMethod (p0);
+		}
 
 		internal static IntPtr class_ref {
-			get { return IGenericTypeInvoker._members.JniPeerType.PeerReference.Handle; }
+			get { return global::jniabi.example.JniabiGenericType._class.JniPeerType.PeerReference.Handle; }
 		}
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
-			get { return IGenericTypeInvoker._members; }
+			get { return global::jniabi.example.JniabiGenericType._class; }
 		}
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		protected override IntPtr ThresholdClass {
-			get { return IGenericTypeInvoker._members.JniPeerType.PeerReference.Handle; }
+			get { return global::jniabi.example.JniabiGenericType._class.JniPeerType.PeerReference.Handle; }
 		}
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
 		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 		protected override global::System.Type ThresholdType {
-			get { return IGenericTypeInvoker._members.ManagedPeerType; }
+			get { return typeof (GenericType); }
 		}
 
-		protected GenericType (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		protected GenericType (IntPtr javaReference, JniHandleOwnership transfer)
+			: base (javaReference, transfer)
 		{
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='example']/class[@name='GenericType']/constructor[@name='GenericType' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe GenericType () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe GenericType ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 
@@ -76,9 +61,83 @@ namespace Example
 				return;
 
 			try {
-				var __r = IGenericTypeInvoker._members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				var __r = global::jniabi.example.JniabiGenericType._class.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
-				IGenericTypeInvoker._members.InstanceMethods.FinishCreateInstance (__id, this, null);
+				global::jniabi.example.JniabiGenericType._class.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='example']/class[@name='GenericType']/method[@name='TestPerformance' and count(parameter)=2 and parameter[1][@type='T'] and parameter[2][@type='int']]"
+		[Register ("TestPerformance", "(Ljava/lang/Object;I)V", "")]
+		public unsafe void TestPerformance (Java.Lang.Object? p0, int p1)
+		{
+			try {
+				global::jniabi.example.JniabiGenericType.TestPerformance (this, p0?.PeerReference ?? default, p1);
+			}
+			finally {
+				GC.KeepAlive (p0);
+			}
+		}
+	}
+
+	[global::Android.Runtime.Register ("example/GenericType", "", "Example.IGenericTypeInvoker", DoNotGenerateAcw = true)]
+	public partial class GenericType<T> : global::Java.Lang.Object, global::jniabi.example._JniabiGenericType
+		where T : global::Java.Lang.Object
+	{
+		[Register ("PerformanceMethod", "(Ljava/lang/Object;)V", "GetPerformanceMethod_Ljava_lang_Object_Handler:jniabi.example._JniabiGenericType, Generic-Binding-Lib")]
+		public virtual unsafe void PerformanceMethod (T? p0)
+		{
+			jniabi.example.JniabiGenericType.PerformanceMethod (this, p0?.PeerReference ?? default);
+		}
+
+		void global::jniabi.example._JniabiGenericType.PerformanceMethod (global::Java.Interop.JniObjectReference native_p0)
+		{
+			var p0 = global::Java.Lang.Object.GetObject<T> (native_p0.Handle, JniHandleOwnership.DoNotTransfer);
+			PerformanceMethod (p0);
+		}
+
+		internal static IntPtr class_ref {
+			get { return global::jniabi.example.JniabiGenericType._class.JniPeerType.PeerReference.Handle; }
+		}
+
+		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return global::jniabi.example.JniabiGenericType._class; }
+		}
+
+		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+		protected override IntPtr ThresholdClass {
+			get { return global::jniabi.example.JniabiGenericType._class.JniPeerType.PeerReference.Handle; }
+		}
+
+		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+		protected override global::System.Type ThresholdType {
+			get { return typeof (GenericType<T>); }
+		}
+
+		protected GenericType (IntPtr javaReference, JniHandleOwnership transfer)
+			: base (javaReference, transfer)
+		{
+		}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='example']/class[@name='GenericType']/constructor[@name='GenericType' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericType ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = global::jniabi.example.JniabiGenericType._class.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				global::jniabi.example.JniabiGenericType._class.InstanceMethods.FinishCreateInstance (__id, this, null);
 			} finally {
 			}
 		}
@@ -87,17 +146,75 @@ namespace Example
 		[Register ("TestPerformance", "(Ljava/lang/Object;I)V", "")]
 		public unsafe void TestPerformance (T p0, int p1)
 		{
-			const string __id = "TestPerformance.(Ljava/lang/Object;I)V";
-			IntPtr native_p0 = JNIEnv.ToLocalJniHandle (p0);
 			try {
-				Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue [2];
-				__args [0] = new Java.Interop.JniArgumentValue (native_p0);
-				__args [1] = new Java.Interop.JniArgumentValue (p1);
-				IGenericTypeInvoker._members.InstanceMethods.InvokeNonvirtualVoidMethod (__id, this, __args);
-			} finally {
-				JNIEnv.DeleteLocalRef (native_p0);
-				global::System.GC.KeepAlive (p0);
+				global::jniabi.example.JniabiGenericType.TestPerformance (this, p0.PeerReference, p1);
+			}
+			finally {
+				GC.KeepAlive (p0);
 			}
 		}
+	}
+}
+
+namespace jniabi.example {
+	using System.ComponentModel;
+	using Java.Interop;
+
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	public static partial class JniabiGenericType {
+
+		public static JniPeerMembers _class => _JniabiGenericType._class;
+
+		public static unsafe void PerformanceMethod (IJavaPeerable self, JniObjectReference obj)
+		{
+			const string __id = "PerformanceMethod.(Ljava/lang/Object;)V";
+			try {
+				Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue [1];
+				__args [0] = new Java.Interop.JniArgumentValue (obj);
+				_JniabiGenericType._class.InstanceMethods.InvokeVirtualVoidMethod (__id, self, __args);
+			} finally {
+				global::System.GC.KeepAlive (self);
+			}
+		}
+
+		public static unsafe void TestPerformance (IJavaPeerable self, JniObjectReference p0, int p1)
+		{
+			const string __id = "TestPerformance.(Ljava/lang/Object;I)V";
+			try {
+				Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue [2];
+				__args [0] = new Java.Interop.JniArgumentValue (p0);
+				__args [1] = new Java.Interop.JniArgumentValue (p1);
+				_JniabiGenericType._class.InstanceMethods.InvokeNonvirtualVoidMethod (__id, self, __args);
+			} finally {
+				global::System.GC.KeepAlive (self);
+			}
+		}
+	}
+
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[Register (JniTypeName)]
+	public interface _JniabiGenericType : IJavaObject, global::Java.Interop.IJavaPeerable {
+
+		public const string JniTypeName = "example/GenericType";
+		public static readonly global::Java.Interop.JniPeerMembers _class = new XAPeerMembers (JniTypeName, typeof (_JniabiGenericType));
+
+		void PerformanceMethod (JniObjectReference obj);
+
+		private static Delegate? cb_PerformanceMethod_Ljava_lang_Object_;
+#pragma warning disable 0169
+		private static Delegate GetPerformanceMethod_Ljava_lang_Object_Handler ()
+		{
+			if (cb_PerformanceMethod_Ljava_lang_Object_ == null)
+				cb_PerformanceMethod_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_PerformanceMethod_Ljava_lang_Object_);
+			return cb_PerformanceMethod_Ljava_lang_Object_;
+		}
+
+		private static void n_PerformanceMethod_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
+		{
+			var __this = global::Java.Lang.Object.GetObject<_JniabiGenericType> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var p0 = new JniObjectReference (native_p0);
+			__this!.PerformanceMethod (p0);
+		}
+#pragma warning restore 0169
 	}
 }

--- a/Generic-Binding-Lib/Additions/Example.ICustomList.cs
+++ b/Generic-Binding-Lib/Additions/Example.ICustomList.cs
@@ -6,43 +6,44 @@ using Android.Runtime;
 namespace Example
 {
 	// Metadata.xml XPath interface reference: path="/api/package[@name='example']/interface[@name='CustomList']"
-	[Register ("example/CustomList", "", "Example.ICustomListInvoker")]
-	[global::Java.Interop.JavaTypeParameters (new string [] { "E" })]
-	public partial interface ICustomList<T> : IJavaObject, Java.Interop.IJavaPeerable, ICustomListInterfaceInvoker where T : global::Java.Lang.Object
+//	[Register ("example/CustomList", "", "Example.ICustomListInvoker", DoNotGenerateAcw = true)]
+//	[global::Java.Interop.JavaTypeParameters (new string [] { "E" })]
+	public partial interface ICustomList<T> : IJavaObject, Java.Interop.IJavaPeerable, global::jniabi.example._JniabiCustomList
+		where T : global::Java.Lang.Object
 	{
 		// Metadata.xml XPath method reference: path="/api/package[@name='example']/interface[@name='CustomList']/method[@name='add' and count(parameter)=1 and parameter[1][@type='E']]"
-		[Register ("add", "(Ljava/lang/Object;)Z", "GetAdd_Ljava_lang_Object_Handler:Example.ICustomListInvoker, Generic-Binding-Lib")]
-		bool Add (T p0);
+		[Register ("add", "(Ljava/lang/Object;)Z", "GetAdd_Ljava_lang_Object_Handler:jniabi.example._JniabiCustomList, Generic-Binding-Lib")]
+		bool Add (T? p0);
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='example']/interface[@name='CustomList']/method[@name='addAll' and count(parameter)=1 and parameter[1][@type='java.util.Collection&lt;? extends E&gt;']]"
-		[Register ("addAll", "(Ljava/util/Collection;)Z", "GetAddAll_Ljava_util_Collection_Handler:Example.ICustomListInvoker, Generic-Binding-Lib")]
-		bool AddAll (global::System.Collections.Generic.ICollection<T> p0);
+		[Register ("addAll", "(Ljava/util/Collection;)Z", "GetAddAll_Ljava_util_Collection_Handler:jniabi.example._JniabiCustomList, Generic-Binding-Lib")]
+		bool AddAll (global::System.Collections.Generic.ICollection<T>? p0);
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='example']/interface[@name='CustomList']/method[@name='get' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("get", "(I)Ljava/lang/Object;", "GetGet_IHandler:Example.ICustomListInvoker, Generic-Binding-Lib")]
-		T Get (int p0);
+		[Register ("get", "(I)Ljava/lang/Object;", "GetGet_IHandler:jniabi.example._JniabiCustomList, Generic-Binding-Lib")]
+		T? Get (int p0);
 
-		bool ICustomListInterfaceInvoker.InvokeAdd (global::Java.Lang.Object obj)
-			=> Add (obj.JavaCast<T> ());
+		bool global::jniabi.example._JniabiCustomList.add (global::Java.Interop.JniObjectReference native_obj)
+		{
+			var obj = global::Java.Lang.Object.GetObject<T> (native_obj.Handle, JniHandleOwnership.DoNotTransfer);
+			return Add (obj);
+		}
 
-		bool ICustomListInterfaceInvoker.InvokeAddAll (global::System.Collections.ICollection obj)
-			=> AddAll (obj.OfType<Java.Lang.Object> ().Select (o => o.JavaCast<T> ()).ToArray ());
+		bool global::jniabi.example._JniabiCustomList.addAll (global::Java.Interop.JniObjectReference native_c)
+		{
+			var c = JavaCollection<T>.FromJniHandle (native_c.Handle, JniHandleOwnership.DoNotRegister);
+			return AddAll (c);
+		}
 
-		global::Java.Lang.Object ICustomListInterfaceInvoker.InvokeGet (int p0)
-			=> Get (p0);
-	}
-
-	public interface ICustomListInterfaceInvoker : IJavaObject, Java.Interop.IJavaPeerable
-	{
-		bool InvokeAdd (global::Java.Lang.Object obj);
-
-		bool InvokeAddAll (global::System.Collections.ICollection obj);
-
-		global::Java.Lang.Object InvokeGet (int p0);
+		global::Java.Interop.JniObjectReference global::jniabi.example._JniabiCustomList.get (int p0)
+		{
+			var r = Get (p0);
+			return new global::Java.Interop.JniObjectReference (JNIEnv.ToLocalJniHandle (r), Java.Interop.JniObjectReferenceType.Local);
+		}
 	}
 
 	[global::Android.Runtime.Register ("example/CustomList", DoNotGenerateAcw = true)]
-	internal partial class ICustomListInvoker : global::Java.Lang.Object
+	internal partial class ICustomListInvoker : global::Java.Lang.Object, global::jniabi.example._JniabiCustomList
 	{
 		static readonly Java.Interop.JniPeerMembers _members = new XAPeerMembers ("example/CustomList", typeof (ICustomListInvoker));
 
@@ -70,9 +71,9 @@ namespace Example
 
 		IntPtr class_ref;
 
-		public static ICustomListInterfaceInvoker GetObject (IntPtr handle, JniHandleOwnership transfer)
+		public static global::jniabi.example._JniabiCustomList? GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
-			return global::Java.Lang.Object.GetObject<ICustomListInterfaceInvoker> (handle, transfer);
+			return global::Java.Lang.Object.GetObject<global::jniabi.example._JniabiCustomList> (handle, transfer);
 		}
 
 		static IntPtr Validate (IntPtr handle)
@@ -97,92 +98,146 @@ namespace Example
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
 
-		static Delegate cb_add_Ljava_lang_Object_;
+		public unsafe bool add (global::Java.Interop.JniObjectReference p0)
+		{
+			return global::jniabi.example.JniabiCustomList.add (this, p0);
+		}
+
+		public unsafe bool addAll (global::Java.Interop.JniObjectReference p0)
+		{
+			return global::jniabi.example.JniabiCustomList.addAll (this, p0);
+		}
+
+		public unsafe global::Java.Interop.JniObjectReference get (int p0)
+		{
+			return global::jniabi.example.JniabiCustomList.get (this, p0);
+		}
+	}
+}
+
+namespace jniabi.example {
+	using System.ComponentModel;
+	using Java.Interop;
+
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	public static partial class JniabiCustomList {
+
+		public static JniPeerMembers _class => _JniabiCustomList._class;
+
+		public static unsafe bool add (IJavaPeerable self, JniObjectReference e)
+		{
+			const string __id = "add.(Ljava/lang/Object;)V";
+			try {
+				Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue [1];
+				__args [0] = new Java.Interop.JniArgumentValue (e);
+				return _class.InstanceMethods.InvokeAbstractBooleanMethod (__id, self, __args);
+			} finally {
+				global::System.GC.KeepAlive (self);
+			}
+		}
+
+		public static unsafe JniObjectReference get(IJavaPeerable self, int index)
+		{
+			const string __id = "get.(I)Ljava/lang/Object;";
+			try {
+				Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue [1];
+				__args [0] = new Java.Interop.JniArgumentValue (index);
+				return _class.InstanceMethods.InvokeAbstractObjectMethod (__id, self, __args);
+			} finally {
+				global::System.GC.KeepAlive (self);
+			}
+		}
+
+		public static unsafe bool addAll(IJavaPeerable self, JniObjectReference c)
+		{
+			const string __id = "addAll.(Ljava/util/Collection;)V";
+			try {
+				Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue [1];
+				__args [0] = new Java.Interop.JniArgumentValue (c);
+				return _class.InstanceMethods.InvokeAbstractBooleanMethod (__id, self, __args);
+			} finally {
+				global::System.GC.KeepAlive (self);
+			}
+		}
+	}
+
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[Register (JniTypeName, DoNotGenerateAcw = true)]
+	public partial interface _JniabiCustomList : IJavaObject, IJavaPeerable {
+		public const string JniTypeName = "example/CustomList";
+		public static readonly Java.Interop.JniPeerMembers _class = new XAPeerMembers (JniTypeName, typeof (_JniabiCustomList), isInterface: true);
+
+		[Register ("add", "(Ljava/lang/Object;)Z", "GetAdd_Ljava_lang_Object_Handler:jniabi.example._JniabiCustomList, Generic-Binding-Lib")]
+		public bool add(JniObjectReference e);
+		[Register ("get", "(I)Ljava/lang/Object;", "GetGet_IHandler:jniabi.example._JniabiCustomList, Generic-Binding-Lib")]
+		public JniObjectReference get(int index);
+		[Register ("addAll", "(Ljava/util/Collection;)Z", "GetAddAll_Ljava_util_Collection_Handler:jniabi.example._JniabiCustomList, Generic-Binding-Lib")]
+		public bool addAll(JniObjectReference p0);
+
+
+		private static Delegate? cb_add_Ljava_lang_Object_;
 #pragma warning disable 0169
-		static Delegate GetAdd_Ljava_lang_Object_Handler ()
+		private static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
 			if (cb_add_Ljava_lang_Object_ == null)
 				cb_add_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_Z) n_Add_Ljava_lang_Object_);
 			return cb_add_Ljava_lang_Object_;
 		}
 
-		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
+		private static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Example.ICustomListInterfaceInvoker> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
-			return __this.InvokeAdd (p0);
+			var __this = global::Java.Lang.Object.GetObject<_JniabiCustomList> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			try {
+				var p0 = new JniObjectReference(native_p0);
+				return __this!.add (p0);
+			}
+			finally {
+				GC.KeepAlive (__this);
+			}
 		}
 #pragma warning restore 0169
 
-		IntPtr id_add_Ljava_lang_Object_;
-		public unsafe bool InvokeAdd (global::Java.Lang.Object p0)
-		{
-			if (id_add_Ljava_lang_Object_ == IntPtr.Zero)
-				id_add_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "add", "(Ljava/lang/Object;)Z");
-			IntPtr native_p0 = JNIEnv.ToLocalJniHandle (p0);
-			JValue* __args = stackalloc JValue [1];
-			__args [0] = new JValue (native_p0);
-			var __ret = JNIEnv.CallBooleanMethod (((global::Java.Lang.Object) this).Handle, id_add_Ljava_lang_Object_, __args);
-			JNIEnv.DeleteLocalRef (native_p0);
-			return __ret;
-		}
-
-		static Delegate cb_addAll_Ljava_util_Collection_;
+		private static Delegate? cb_addAll_Ljava_util_Collection_;
 #pragma warning disable 0169
-		static Delegate GetAddAll_Ljava_util_Collection_Handler ()
+		private static Delegate GetAddAll_Ljava_util_Collection_Handler ()
 		{
 			if (cb_addAll_Ljava_util_Collection_ == null)
 				cb_addAll_Ljava_util_Collection_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_Z) n_AddAll_Ljava_util_Collection_);
 			return cb_addAll_Ljava_util_Collection_;
 		}
 
-		static bool n_AddAll_Ljava_util_Collection_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
+		private static bool n_AddAll_Ljava_util_Collection_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Example.ICustomListInterfaceInvoker> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = global::Android.Runtime.JavaCollection.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
-			bool __ret = __this.InvokeAddAll (p0);
-			return __ret;
+			var __this = global::Java.Lang.Object.GetObject<_JniabiCustomList> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			try {
+				var p0 = new JniObjectReference(native_p0);
+				return __this!.addAll (p0);
+			}
+			finally {
+				GC.KeepAlive (__this);
+			}
 		}
 #pragma warning restore 0169
 
-		IntPtr id_addAll_Ljava_util_Collection_;
-		public unsafe bool InvokeAddAll (global::System.Collections.ICollection p0)
-		{
-			if (id_addAll_Ljava_util_Collection_ == IntPtr.Zero)
-				id_addAll_Ljava_util_Collection_ = JNIEnv.GetMethodID (class_ref, "addAll", "(Ljava/util/Collection;)Z");
-			IntPtr native_p0 = global::Android.Runtime.JavaCollection.ToLocalJniHandle (p0);
-			JValue* __args = stackalloc JValue [1];
-			__args [0] = new JValue (native_p0);
-			var __ret = JNIEnv.CallBooleanMethod (((global::Java.Lang.Object) this).Handle, id_addAll_Ljava_util_Collection_, __args);
-			JNIEnv.DeleteLocalRef (native_p0);
-			return __ret;
-		}
-
-		static Delegate cb_get_I;
+		private static Delegate? cb_get_I;
 #pragma warning disable 0169
-		static Delegate GetGet_IHandler ()
+		private static Delegate GetGet_IHandler ()
 		{
 			if (cb_get_I == null)
 				cb_get_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_L) n_Get_I);
 			return cb_get_I;
 		}
 
-		static IntPtr n_Get_I (IntPtr jnienv, IntPtr native__this, int p0)
+		private static IntPtr n_Get_I (IntPtr jnienv, IntPtr native__this, int p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Example.ICustomListInterfaceInvoker> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.InvokeGet (p0));
+			var __this = global::Java.Lang.Object.GetObject<_JniabiCustomList> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			try {
+				return __this!.get (p0).Handle;
+			}
+			finally {
+				GC.KeepAlive (__this);
+			}
 		}
 #pragma warning restore 0169
-
-		IntPtr id_get_I;
-		public unsafe global::Java.Lang.Object InvokeGet (int p0)
-		{
-			if (id_get_I == IntPtr.Zero)
-				id_get_I = JNIEnv.GetMethodID (class_ref, "get", "(I)Ljava/lang/Object;");
-			JValue* __args = stackalloc JValue [1];
-			__args [0] = new JValue (p0);
-			return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_get_I, __args), JniHandleOwnership.TransferLocalRef);
-		}
-
 	}
 }


### PR DESCRIPTION
Introduce an "explicit ABI" concept

Context: https://devblogs.microsoft.com/oldnewthing/20210830-00/?p=105617
Context: https://github.com/xamarin/java.interop/issues/795
Context: https://github.com/xamarin/java.interop/issues/910

It occurs to @jonpryor that what we're dealing with is *kinda* like
the world of COM and COM-related technologies; see [oldnewthing][0].

> C++/WinRT and C++/CX set up parallel universes like this:
>
> | C++/WinRT               | ABI                       | C++/CX            |
> | ----------------------- | ------------------------- | ----------------- |
> | winrt::Contoso::Widget  | ABI::Contoso::Widget\*    | Contoso::Widget^  |

We have an "ABI": what JNI expects/requires.

Then we have a "projection" ("binding") from the ABI, for consumption
by end users.

*Historically*, we "hand-waved" over the ABI; it was *implicit* to
how things worked, but *not* something that customers interacted with
directly.

@jonpryor would like to change that, and this seems like a reasonable
"two birds, one stone" opportunity.

The support for generic types, as described in `readm.md`, is
contingent upon a "layer of indirection":

> - Java calls the static invoker
> - The static invoker calls the instance invoker
> - The instance invoker calls the desired method

The "instance invoker" is the "layer of indirection".

The original prototype "named" this "layer of indirection"
`I[Java type name]Invoker`; e.g. given Java:

	// Java
	package example;

	public interface ArrayList<E> {
	    void add(E obj);
	}

we'd have "binding + infrastructure" of:

	// C#
	namespace Example {
	    public partial interface IArrayList<E> {
	        void Add(E obj);
	    }
	    public partial interface IArrayListInvoker {
	        void InvokeAdd(Java.Lang.Object obj);
	    }
	}

My proposal is to take some ideas from xamarin/java.interop#795
and WinRT projections, "formalizing" the ABI:

	// Convention: `jniabi.` + *Java* package name
	namespace jniabi.example {

	    // Convention: `Jniabi` prefix + Java type name
	    [EditorBrowsable (EditorBrowsableState.Never)]
	    public static partial class JniabiArrayList {
	        // Convention: Java method name + "suffix" for overloads; uses "lowest level" types.
	        public static void add(IJavaPeerable self, JniObjectReference obj);
	    }

	    // Convention: `_Jniabi` prefix + Java name suffix;
	    [EditorBrowsable (EditorBrowsableState.Never)]
	    [Register ("example/ArrayList", DoNotGenerateAcw=true)]
	    public partial interface _JniabiArrayList : IJavaObject, IJavaPeerable {
	        // Convention: Java method name + "suffix" for overloads; uses "lowest level" types.
	        [Register ("add", "(Ljava/lang/Object;)V", …);
	        void add(JniObjectReference obj);

	        // jni marshal method glue…
	        private static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
	        {
	            var __this = Java.Lang.Object.GetObject<_ArrayList>(native__this);
	            __this!.add (new JniObjectReference (native_p0));
	        }
	    }
	}

[`[EditorBrowsable(EditorBrowsableState.Never)]`][1] is used to hide
these types from normal IDE code completion scenarios.  They're
intended for internal use.

The `jniabi.example.JniabiArrayList` static class is for "manual
binding" scenarios; see also xamarin-android/src/Mono.Android, which
has a fair bit of "hand-written" code which was produced by taking
`generator` output and copying it.  `jniabi.example.JniabiArrayList`
is meant to remove the need for hand-copying code, but *only* provides
low-level bindings.  Actual type marshaling/etc. is "elsewhere".
It is also useful as part of xamarin/java.interop#910, to allow
"interface Invokers" to begin caching `jmethodID` values.

The `jniabi.example._JniabiArrayList` interface is the layer of
indirection, so that generic types *can* work.  It's not "meant" for
implementation by "normal" people, but *can* be implemented if they
want/need to take control of marshaling.  (For example, Photo data
marshaling is like a 12MB `byte[]` that needs to be marshaled EVERY
TIME, contributing to perf issues.  Being able to interject and do
"something else" could be *really* useful for some scenarios.)

Note: wrt xamarin/java.interop#795, `_JniabiArrayList` was instead
written as `jnimarshalmethod.example.ArrayList`.  I tried this
initially, but wasn't "thrilled" with how it looked.  Please discuss.

We then separate out the "projection" ("binding"), in terms of the ABI:

	namespace Example {
	    // Note: *NO* [Register]; always implements ABI
	    public partial interface IArrayList<E> : IJavaObject, IJavaPeerable, global::jniabi.example._ArrayList
	    {
	        void Add (E obj); // projection

	        // "glue" from ABI to projection; explicitly implemented
	        void jniabi.example._JniabiArrayList.add(JniObjectReference native_obj)
	        {
	            var obj = Java.Lang.Object.GetObject<T>(native_obj.Handle);
	            Add (obj);
	        }
	    }
	}

"Of course", we also want/need the raw types in the projection, if
only for backward compatibility (we've historically *only* bound raw
types), and this "slots in":

	namespace Example {
	    // Note: *NO* [Register]; always implements ABI
	    public partial interface IArrayList : IJavaObject, IJavaPeerable, global::jniabi.example._ArrayList
	    {
	        void Add (Java.Lang.Object? obj); // projection

	        // "glue" from ABI to projection; explicitly implemented
	        void jniabi.example._JniabiArrayList.add(JniObjectReference native_obj)
	        {
	            var obj = Java.Lang.Object.GetObject<Java.Lang.Object>(native_obj.Handle);
	            Add (obj);
	        }
	    }
	}

The downside to having the raw type implement the ABI
`_JniabiArrayList` type is that it *also* incurs the indirection
penalty.

It *is* really flexible though!

Pros to this approach vs. the "original prototype":

  * Reduces "namespace pollution" by moving the "indirection" types
    into a separate set of namespaces.  I rather doubt that anyone
    will "accidentally" find the `jniabi.…` namespace.

  * Makes the ABI explicit, which in turn inserts flexibility.
    What if you don't *want* `java.util.Collection` to be marshaled
    as an `IEnumerable<T>`?  With this approach, you can control it.

  * It's also really awesome looking to be within a generic class and
    use `Object.GetObject<T>()`, using the type parameter directly.

  * Use of Java-originated identifier names (hopefully?) reduces
    complexity.  (I can hope, right?)

Cons:

  * Use of Java-originated identifier names may complicate things.
    Sure, they're still accessible via the `generator` object model,
    but that doesn't mean everything is "fine".
    (If wishes were horses…)

  * "ABI" names *will* need to involve "hashes" for overloads, at
    some point, because all reference types "devolve" to
    `JniObjectReference`, so unless the number of parameters differs,
    method overloads that use "separate yet reference types" will
    collide, e.g. `java.lang.String.getBytes(String)` vs.
    `java.lang.String.getBytes(java.nio.charset.Charset)`.
    The `jniabi.java.lang.String` type will need to expose e.g.
    `getBytes_hash1()` and `getBytes_hash2()` methods, where the
    hash is e.g. the CRC for the JNI method signature.

[0]: https://devblogs.microsoft.com/oldnewthing/20210830-00/?p=105617
[1]: https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.editorbrowsableattribute?view=net-6.0
